### PR TITLE
chore(error): easier-to-catch errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,8 @@ async function startMcpServer() {
         const result = await understand(db, { query: params.query, top_k: params.top_k });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        return { content: [{ type: "text" as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
       }
     }
   );
@@ -213,7 +214,8 @@ async function startMcpServer() {
         });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        return { content: [{ type: "text" as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
       }
     }
   );
@@ -239,7 +241,8 @@ async function startMcpServer() {
         });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        return { content: [{ type: "text" as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
       }
     }
   );
@@ -262,7 +265,8 @@ async function startMcpServer() {
         });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        return { content: [{ type: "text" as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
       }
     }
   );
@@ -279,7 +283,8 @@ async function startMcpServer() {
         const result = removeConcept(db, { id: params.id, reason: params.reason });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        return { content: [{ type: "text" as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
       }
     }
   );
@@ -293,7 +298,15 @@ async function startMcpServer() {
         const result = listRoots(db);
         return { content: [{ type: "text" as const, text: JSON.stringify({ ...result, stats: db.getStats() }, null, 2) }] };
       } catch (err) {
-        return { content: [{ type: "text" as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        // Prefix with clear marker for preflight check detection
+        return { 
+          content: [{ 
+            type: "text" as const, 
+            text: `MEGAMEMORY_ERROR: ${errorMsg}` 
+          }], 
+          isError: true 
+        };
       }
     }
   );
@@ -307,7 +320,8 @@ async function startMcpServer() {
         const result = listConflicts(db);
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        return { content: [{ type: "text" as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
       }
     }
   );
@@ -333,7 +347,8 @@ async function startMcpServer() {
         });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        return { content: [{ type: "text" as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
       }
     }
   );


### PR DESCRIPTION
If the database doesn't exist or other error occured, return MEGAMEMORY_ERROR instead of Error. Primary use is for the preflight check of gsd-mm that makes sure it's a valid project.

Code written by GLM-4.7