### PR TITLE
feat(error): easier-to-catch errors

### DIFF
--- a/src/__tests__/error-formatting.test.ts
+++ b/src/__tests__/error-formatting.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { formatError } from "../tools.js";
+
+describe("formatError", () => {
+  it("formats Error instances with MEGAMEMORY_ERROR prefix", () => {
+    const error = new Error("Something went wrong");
+    const result = formatError(error);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toBe("MEGAMEMORY_ERROR: Something went wrong");
+    expect(result.isError).toBe(true);
+  });
+
+  it("formats non-Error objects with MEGAMEMORY_ERROR prefix", () => {
+    const error = "String error message";
+    const result = formatError(error);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toBe("MEGAMEMORY_ERROR: String error message");
+    expect(result.isError).toBe(true);
+  });
+
+  it("formats numbers with MEGAMEMORY_ERROR prefix", () => {
+    const error = 404;
+    const result = formatError(error);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toBe("MEGAMEMORY_ERROR: 404");
+    expect(result.isError).toBe(true);
+  });
+
+  it("formats null with MEGAMEMORY_ERROR prefix", () => {
+    const result = formatError(null);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toBe("MEGAMEMORY_ERROR: null");
+    expect(result.isError).toBe(true);
+  });
+
+  it("formats undefined with MEGAMEMORY_ERROR prefix", () => {
+    const result = formatError(undefined);
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toBe("MEGAMEMORY_ERROR: undefined");
+    expect(result.isError).toBe(true);
+  });
+
+  it("preserves error messages with special characters", () => {
+    const error = new Error("Error: Database 'test.db' not found at /path/to/file");
+    const result = formatError(error);
+
+    expect(result.content[0].text).toBe("MEGAMEMORY_ERROR: Error: Database 'test.db' not found at /path/to/file");
+    expect(result.isError).toBe(true);
+  });
+
+  it("always returns isError: true", () => {
+    const error1 = new Error("Test");
+    const error2 = "String error";
+    const error3 = 123;
+
+    expect(formatError(error1).isError).toBe(true);
+    expect(formatError(error2).isError).toBe(true);
+    expect(formatError(error3).isError).toBe(true);
+  });
+
+  it("always returns array with single content item", () => {
+    const result1 = formatError(new Error("Test"));
+    const result2 = formatError("String error");
+
+    expect(result1.content).toHaveLength(1);
+    expect(result2.content).toHaveLength(1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,13 @@ switch (cmd) {
       process.exit(1);
     }
     // No command → start MCP server (normal invocation by editor)
-    await startMcpServer();
+    try {
+      await startMcpServer();
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      console.error(`MEGAMEMORY_ERROR: ${errorMsg}`);
+      process.exit(1);
+    }
     break;
 }
 
@@ -137,7 +143,7 @@ async function startMcpServer() {
   const { z } = await import("zod");
   const path = await import("path");
   const { KnowledgeDB } = await import("./db.js");
-  const { understand, createConcept, updateConcept, link, removeConcept, listRoots, listConflicts, resolveConflict } =
+  const { understand, createConcept, updateConcept, link, removeConcept, listRoots, listConflicts, resolveConflict, formatError } =
     await import("./tools.js");
 
   type NodeKind = import("./types.js").NodeKind;
@@ -177,8 +183,7 @@ async function startMcpServer() {
         const result = await understand(db, { query: params.query, top_k: params.top_k });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
+        return formatError(err);
       }
     }
   );
@@ -214,8 +219,7 @@ async function startMcpServer() {
         });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
+        return formatError(err);
       }
     }
   );
@@ -241,8 +245,7 @@ async function startMcpServer() {
         });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
+        return formatError(err);
       }
     }
   );
@@ -265,8 +268,7 @@ async function startMcpServer() {
         });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
+        return formatError(err);
       }
     }
   );
@@ -283,8 +285,7 @@ async function startMcpServer() {
         const result = removeConcept(db, { id: params.id, reason: params.reason });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
+        return formatError(err);
       }
     }
   );
@@ -298,8 +299,7 @@ async function startMcpServer() {
         const result = listRoots(db);
         return { content: [{ type: "text" as const, text: JSON.stringify({ ...result, stats: db.getStats() }, null, 2) }] };
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
+        return formatError(err);
       }
     }
   );
@@ -313,8 +313,7 @@ async function startMcpServer() {
         const result = listConflicts(db);
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
+        return formatError(err);
       }
     }
   );
@@ -340,8 +339,7 @@ async function startMcpServer() {
         });
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err) {
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }], isError: true };
+        return formatError(err);
       }
     }
   );

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -17,6 +17,14 @@ import type {
 } from "./types.js";
 import { stripMergeSuffix } from "./merge.js";
 
+export function formatError(err: unknown): { content: Array<{ type: "text"; text: string }>; isError: true } {
+  const errorMsg = err instanceof Error ? err.message : String(err);
+  return {
+    content: [{ type: "text" as const, text: `MEGAMEMORY_ERROR: ${errorMsg}` }],
+    isError: true,
+  };
+}
+
 /**
  * Generate a slug ID from a name, optionally prefixed with parent ID.
  * Converts underscores and spaces to hyphens, lowercases, strips non-alphanumeric.


### PR DESCRIPTION
If the database doesn't exist or other error occured, return MEGAMEMORY_ERROR instead of Error. Primary use is for the preflight check of gsd-mm that makes sure it's a valid project.

Code written by GLM-4.7